### PR TITLE
Use proper schedule key

### DIFF
--- a/converter/convert.go
+++ b/converter/convert.go
@@ -2,11 +2,12 @@ package converter
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/actions/workflow-parser/model"
 	"github.com/actions/workflow-parser/parser"
@@ -169,7 +170,7 @@ func convertGithubEnvironmentReferences(s string) string {
 func writeOn(w *workflow, on model.On) {
 	if o, ok := on.(*model.OnSchedule); ok {
 		w.OnSchedule = map[string][]map[string]string{
-			"schedules": {
+			"schedule": {
 				{
 					"cron": o.Expression,
 				},

--- a/converter/convert_test.go
+++ b/converter/convert_test.go
@@ -104,7 +104,7 @@ jobs:
 	})
 }
 
-func TestConvertOneSchedules(t *testing.T) {
+func TestConvertOneSchedule(t *testing.T) {
 	assertCorrect(t, eg{
 		input: `workflow "scheduled" {
   on = "schedule(* * * * *)"
@@ -126,7 +126,7 @@ action "A" {
 `,
 		output: map[string]string{
 			".github/workflows/schedule-scheduled.yml": `on:
-  schedules:
+  schedule:
   - cron: '* * * * *'
 name: scheduled
 jobs:
@@ -138,7 +138,7 @@ jobs:
       uses: ./A
 `,
 			".github/workflows/schedule-scheduled-two.yml": `on:
-  schedules:
+  schedule:
   - cron: '* * * * *'
 name: scheduled two
 jobs:

--- a/fixtures/mega-test/.github/workflows/schedule.yml
+++ b/fixtures/mega-test/.github/workflows/schedule.yml
@@ -1,5 +1,5 @@
 on:
-  schedules:
+  schedule:
   - cron: 00 08 * * 1
 name: Top 5
 jobs:

--- a/fixtures/schedules/.github/workflows/schedule.yml
+++ b/fixtures/schedules/.github/workflows/schedule.yml
@@ -1,5 +1,5 @@
 on:
-  schedules:
+  schedule:
   - cron: '* * * * *'
 name: per minute
 jobs:


### PR DESCRIPTION
This PR fixes https://github.com/actions/migrate/issues/36 by using `schedule` instead of `schedules` as the key.